### PR TITLE
Edit delay for presence pulse check

### DIFF
--- a/src/onewire.c
+++ b/src/onewire.c
@@ -35,7 +35,7 @@ uint8_t onewireInit( volatile uint8_t *port, volatile uint8_t *direction, volati
 
 	*direction &= ~mask; //Set port to input
 
-	_delay_us( 100 );
+	_delay_us( 70 );
 
 	response = *portin & mask; //Read input
 


### PR DESCRIPTION
As per the datasheet at https://datasheets.maximintegrated.com/en/ds/DS18B20.pdf, the minimum time from end of reset pulse to end of presence pulse is 75us.  Maximum time until start of presence pulse is 60us.